### PR TITLE
Setup envoy and docker

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3'
+services:
+    envoy:
+        build: ./envoy
+        ports:
+            - "9901:9901"
+            - "10000:10000"
+        links:
+            - dcsdk_backend
+    dcsdk_backend:
+        image: mrpollo/dronecode-sdk-backend
+        ports:
+            - "50051:50051"
+            - "14540:14540/udp"
+    gazebo_sitl_headless:
+        image: jonasvautherin/px4-gazebo-headless:v1.8.0
+        environment:
+            - NO_PXH=1
+        links:
+            - dcsdk_backend

--- a/docker/envoy/Dockerfile
+++ b/docker/envoy/Dockerfile
@@ -1,0 +1,3 @@
+FROM envoyproxy/envoy:latest
+
+COPY envoy.yaml /etc/envoy/envoy.yaml

--- a/docker/envoy/envoy.yaml
+++ b/docker/envoy/envoy.yaml
@@ -1,0 +1,45 @@
+admin:
+  access_log_path: /tmp/admin_access.log
+  address:
+    socket_address: { address: 0.0.0.0, port_value: 9901 }
+
+static_resources:
+  listeners:
+  - name: listener_0
+    address:
+      socket_address: { address: 0.0.0.0, port_value: 10000 }
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        config:
+          codec_type: auto
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains: ["*"]
+              routes:
+              - match: { prefix: "/" }
+                route:
+                  cluster: greeter_service
+                  max_grpc_timeout: 0s
+              cors:
+                allow_origin:
+                - "*"
+                allow_methods: GET,PUT,DELETE,POST,OPTIONS
+                allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
+                max_age: "1728000"
+                expose_headers: custom-header-1,grpc-status,grpc-message
+                enabled: true
+          http_filters:
+          - name: envoy.grpc_web
+          - name: envoy.cors
+          - name: envoy.router
+  clusters:
+  - name: greeter_service
+    connect_timeout: 2.25s
+    type: logical_dns
+    http2_protocol_options: {}
+    lb_policy: round_robin
+    hosts: [{ socket_address: { address: dcsdk_backend, port_value: 50051 }}]

--- a/generator.sh
+++ b/generator.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 WORK_DIR="./src"
-PROTO_DIR="/proto/protos"
+PROTO_DIR="proto/protos"
 SDK_DIR="${WORK_DIR}/dronecode_sdk"
 JS_IMPORT_STYLE="commonjs"
 PROTOS=`find ${PROTO_DIR} -name "*.proto" -type f`

--- a/src/dronecode_sdk/action/action.js
+++ b/src/dronecode_sdk/action/action.js
@@ -1,4 +1,4 @@
-const { ArmRequest } = require('./action_pb');
+const { ArmRequest, TakeoffRequest } = require('./action_pb');
 const { ActionServicePromiseClient } = require('./action_grpc_web_pb');
 
 class Action {
@@ -22,6 +22,11 @@ class Action {
     arm() {
         const request = new ArmRequest();
         return this.plugin.arm(request);
+    }
+
+    takeoff() {
+        const request = new TakeoffRequest();
+        return this.plugin.takeoff(request);
     }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import Vehicle from './dronecode_sdk/vehicle';
 
-new Vehicle('127.0.0.1', 10000, false).connect().then((vehicle) => {
+new Vehicle('http://127.0.0.1', 10000, false).connect().then((vehicle) => {
   vehicle.action.then(function(action) {
     action.arm().then(() => {
       console.log('vehicle ready');
@@ -8,7 +8,13 @@ new Vehicle('127.0.0.1', 10000, false).connect().then((vehicle) => {
     }).catch((error) => {
       console.log('ponchis');
       console.log(error);
-    })
+    }).then(() => {
+        console.log('taking off');
+        action.takeoff()
+    }).catch((error) => {
+        console.log('takeoff failed');
+        console.log(error);
+    });
   });
   // console.log(vehicle.action.arm);
 });


### PR DESCRIPTION
* Fix generator script
* Fix client connection address
* Add docker for development setup

This comes with docker-compose. Run it with:

```sh
cd ./docker
docker-compose up # as a deamon: docker-compose up -d
```

Then you can normally run the npm stuff, and `index.js` should make it takeoff.

```sh
npm start
```

Bonus: you can run QGC on your host and it should work.
Note: this is running SITL headless, so you don't see the nice 3D world and all. You could comment out the `gazebo_sitl_headless` configuration in `docker-compose.yml` and run jMAVSim on your host, but on macOS I doubt it will work. It does work on Linux, though.

Very last note: Maaan, I spent 3 hours finding the `NO_PXH=1` solution :sweat_smile: (I tried many other things before, I did not know it just existed).