### PR TITLE
docker: update containers

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,7 +13,7 @@ services:
             - "50051:50051"
             - "14540:14540/udp"
     gazebo_sitl_headless:
-        image: jonasvautherin/px4-gazebo-headless:v1.10.1
+        image: jonasvautherin/px4-gazebo-headless:1.11.0
         environment:
             - NO_PXH=1
         links:

--- a/docker/envoy/Dockerfile
+++ b/docker/envoy/Dockerfile
@@ -1,3 +1,3 @@
-FROM envoyproxy/envoy:v1.11.0
+FROM envoyproxy/envoy:v1.17.1
 
 COPY envoy.yaml /etc/envoy/envoy.yaml

--- a/docker/envoy/envoy.yaml
+++ b/docker/envoy/envoy.yaml
@@ -10,8 +10,9 @@ static_resources:
       socket_address: { address: 0.0.0.0, port_value: 10000 }
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
-        config:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: auto
           stat_prefix: ingress_http
           route_config:
@@ -23,30 +24,32 @@ static_resources:
               - match: { prefix: "/" }
                 route:
                   cluster: greeter_service
-                  max_grpc_timeout: 0s
+                  max_stream_duration:
+                    grpc_timeout_header_max: 0s
               cors:
-                allow_origin:
-                - "*"
-                allow_methods: GET,PUT,DELETE,POST,OPTIONS
+                allow_origin_string_match:
+                - prefix: "*"
+                allow_methods: GET, PUT, DELETE, POST, OPTIONS
                 allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
                 max_age: "1728000"
                 expose_headers: custom-header-1,grpc-status,grpc-message
           http_filters:
-          - name: envoy.grpc_web
-          - name: envoy.cors
-          - name: envoy.router
+          - name: envoy.filters.http.grpc_web
+          - name: envoy.filters.http.cors
+          - name: envoy.filters.http.router
   clusters:
   - name: greeter_service
-    connect_timeout: 2.25s
+    connect_timeout: 0.25s
     type: logical_dns
     http2_protocol_options: {}
     lb_policy: round_robin
+    # win/mac hosts: Use address: host.docker.internal instead of address: localhost in the line below
     load_assignment:
-        cluster_name: mavsdk_server
-        endpoints:
-            - lb_endpoints:
-                - endpoint:
-                    address:
-                        socket_address:
-                            address: mavsdk_server
-                            port_value: 50051
+      cluster_name: mavsdk_server
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: mavsdk_server
+                    port_value: 50051

--- a/docker/mavsdk_server/Dockerfile
+++ b/docker/mavsdk_server/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 RUN apt-get update && \
     apt-get install -y curl
 
-RUN curl -L https://github.com/mavlink/MAVSDK/releases/download/v0.24.0/mavsdk_server_manylinux1-x64 -o /root/mavsdk_server
+RUN curl -L https://github.com/mavlink/MAVSDK/releases/download/v0.37.0/mavsdk_server_manylinux2010-x64 -o /root/mavsdk_server
 
 RUN chmod +x /root/mavsdk_server
 


### PR DESCRIPTION
With the newer version of mavsdk_server we don't see any log output anymore. I assume the problem is that we no longer use `std::endl` so output is not flushed.