### PR TITLE
envoy: fix streams dropping after 16 seconds

### DIFF
--- a/docker/envoy/envoy.yaml
+++ b/docker/envoy/envoy.yaml
@@ -24,6 +24,7 @@ static_resources:
               - match: { prefix: "/" }
                 route:
                   cluster: greeter_service
+                  timeout: 0s # otherwise grpc streams get stopped
                   max_stream_duration:
                     grpc_timeout_header_max: 0s
               cors:


### PR DESCRIPTION
Without this option, infinite streams will get stopped after 16 seconds.